### PR TITLE
Enhance Dashboard with mock data and Copilot dialog

### DIFF
--- a/frontend/src/mockApi.ts
+++ b/frontend/src/mockApi.ts
@@ -1,0 +1,13 @@
+import { Project } from './types';
+
+export const fetchMockProjects = (): Promise<Project[]> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        { id: 1, name: 'Apollo Program', members: [1, 2, 3, 4] },
+        { id: 2, name: 'Gemini Mission', members: [2, 3] },
+        { id: 3, name: 'Mercury Ops', members: [1, 4] },
+      ]);
+    }, 500);
+  });
+};

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,5 @@
+export interface Project {
+  id: number;
+  name: string;
+  members: number[];
+}


### PR DESCRIPTION
## Summary
- add shared Project type and mock API to supply placeholder project data
- load real projects if available and fall back to mock data
- centralize the Copilot feature via a dialog with input form
- place an "Ask the Copilot" card at the top of the dashboard grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842136bf86483288a6e7f13dc38c097