### PR TITLE
Add shared layout with navbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import KanbanBoard from './components/KanbanBoard';
+import Layout from './components/Layout';
 
 function App() {
   return (
     <Router>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/kanban" element={<KanbanBoard />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/kanban" element={<KanbanBoard />} />
+        </Routes>
+      </Layout>
     </Router>
   );
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
-  AppBar,
   Toolbar,
   Typography,
-  IconButton,
   Box,
   Container,
   Grid,
@@ -20,16 +18,14 @@ import {
   List,
   ListItem,
   ListItemText,
-  CssBaseline,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
   TextField,
 } from '@mui/material';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import AccountCircle from '@mui/icons-material/AccountCircle';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
+
+import Layout from './Layout';
 import { useNavigate } from 'react-router-dom';
 import { Project } from '../types';
 import { fetchMockProjects } from '../mockApi';
@@ -74,24 +70,8 @@ export default function Dashboard() {
   };
 
   return (
-    <Box sx={{ display: 'flex' }}>
-      <CssBaseline />
-      <AppBar position="fixed">
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            AI Copilot
-          </Typography>
-          <IconButton color="inherit" size="large">
-            <Brightness4Icon />
-          </IconButton>
-          <IconButton color="inherit" size="large">
-            <NotificationsIcon />
-          </IconButton>
-          <IconButton color="inherit" size="large">
-            <AccountCircle />
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+    <Layout>
+      <Box sx={{ display: 'flex' }}>
       <Drawer
         variant="permanent"
         anchor="right"
@@ -122,7 +102,6 @@ export default function Dashboard() {
         </Box>
       </Drawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3, mr: `${drawerWidth}px` }}>
-        <Toolbar />
         <Container maxWidth="lg">
           <Grid container spacing={3}>
             <Grid item xs={12}>
@@ -195,5 +174,6 @@ export default function Dashboard() {
         </DialogActions>
       </Dialog>
     </Box>
+    </Layout>
   );
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -25,7 +25,6 @@ import {
   TextField,
 } from '@mui/material';
 
-import Layout from './Layout';
 import { useNavigate } from 'react-router-dom';
 import { Project } from '../types';
 import { fetchMockProjects } from '../mockApi';
@@ -70,8 +69,7 @@ export default function Dashboard() {
   };
 
   return (
-    <Layout>
-      <Box sx={{ display: 'flex' }}>
+    <Box sx={{ display: 'flex' }}>
       <Drawer
         variant="permanent"
         anchor="right"
@@ -174,6 +172,5 @@ export default function Dashboard() {
         </DialogActions>
       </Dialog>
     </Box>
-    </Layout>
   );
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -9,6 +9,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import Layout from './Layout';
 
 interface Task {
   id: number;
@@ -97,29 +98,31 @@ export default function KanbanBoard() {
   };
 
   return (
-    <Box sx={{ display: 'flex', gap: 2, p: 2, overflowX: 'auto' }}>
-      {statuses.map((status) => (
-        <Box
-          key={status}
-          onDragOver={(e) => e.preventDefault()}
-          onDrop={() => handleDrop(status)}
-          sx={{ width: 260, minHeight: 300, bgcolor: '#f5f5f5', p: 1, borderRadius: 1 }}
-        >
-          <Typography variant="h6" align="center" gutterBottom>
-            {status}
-          </Typography>
-          {tasks
-            .filter((t) => t.status === status)
-            .map((task) => (
-              <TaskItem
-                key={task.id}
-                task={task}
-                onUpdateName={updateTaskName}
-                onDragStart={handleDragStart}
-              />
-            ))}
-        </Box>
-      ))}
-    </Box>
+    <Layout>
+      <Box sx={{ display: 'flex', gap: 2, p: 2, overflowX: 'auto' }}>
+        {statuses.map((status) => (
+          <Box
+            key={status}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => handleDrop(status)}
+            sx={{ width: 260, minHeight: 300, bgcolor: '#f5f5f5', p: 1, borderRadius: 1 }}
+          >
+            <Typography variant="h6" align="center" gutterBottom>
+              {status}
+            </Typography>
+            {tasks
+              .filter((t) => t.status === status)
+              .map((task) => (
+                <TaskItem
+                  key={task.id}
+                  task={task}
+                  onUpdateName={updateTaskName}
+                  onDragStart={handleDragStart}
+                />
+              ))}
+          </Box>
+        ))}
+      </Box>
+    </Layout>
   );
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -9,7 +9,6 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import Layout from './Layout';
 
 interface Task {
   id: number;
@@ -98,8 +97,7 @@ export default function KanbanBoard() {
   };
 
   return (
-    <Layout>
-      <Box sx={{ display: 'flex', gap: 2, p: 2, overflowX: 'auto' }}>
+    <Box sx={{ display: 'flex', gap: 2, p: 2, overflowX: 'auto' }}>
         {statuses.map((status) => (
           <Box
             key={status}
@@ -123,6 +121,5 @@ export default function KanbanBoard() {
           </Box>
         ))}
       </Box>
-    </Layout>
   );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { AppBar, Toolbar, Typography, IconButton, CssBaseline, Box } from '@mui/material';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <CssBaseline />
+      <AppBar position="fixed">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            AI Copilot
+          </Typography>
+          <IconButton color="inherit" size="large">
+            <Brightness4Icon />
+          </IconButton>
+          <IconButton color="inherit" size="large">
+            <NotificationsIcon />
+          </IconButton>
+          <IconButton color="inherit" size="large">
+            <AccountCircle />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Toolbar />
+      {children}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Layout` component with navbar
- wrap `Dashboard` and `KanbanBoard` pages with the new layout

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68421ae81bd8832897f45b7e2b04e77e