### PR TITLE
Wrap pages with Layout via App routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import KanbanBoard from './components/KanbanBoard';
+import Layout from './components/Layout';
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/kanban" element={<KanbanBoard />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/kanban" element={<KanbanBoard />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import { Outlet } from 'react-router-dom';
+
+export default function Layout() {
+  return (
+    <Box sx={{ py: 2 }}>
+      <Container maxWidth="lg">
+        <Outlet />
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Layout` component with `Outlet`
- use `Layout` as root route element in `App.tsx`
- nest dashboard and kanban board routes under the layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421cdfc3888328abc3933c8c308882